### PR TITLE
Args Removal

### DIFF
--- a/cmd_cc_activate.go
+++ b/cmd_cc_activate.go
@@ -145,7 +145,7 @@ func getActivationFlags() map[string]Flag {
 }
 
 // TODO: maybe add the keepXs in a struct. And reminders. Just for organization
-func activateFunction(cfg *Config, args []Argument) error {
+func activateFunction(cfg *Config) error {
 
 	flags := getActivationFlags()
 

--- a/cmd_cc_add.go
+++ b/cmd_cc_add.go
@@ -91,7 +91,7 @@ func getAddCCFlags() map[string]Flag {
 }
 
 // look into removing the args thing, might have to stay
-func addCCFunction(cfg *Config, args []Argument) error {
+func addCCFunction(cfg *Config) error {
 	var nilProtocol database.Protocol
 	protocol, err := getStructPrompt(cfg, "Enter a protocol for the cards be used with", getProtocolStruct)
 	if err != nil {

--- a/cmd_cc_deactivate.go
+++ b/cmd_cc_deactivate.go
@@ -86,7 +86,7 @@ func getDeactivationFlags() map[string]Flag {
 }
 
 // look into removing the args thing, might have to stay
-func deactivateFunction(cfg *Config, args []Argument) error {
+func deactivateFunction(cfg *Config) error {
 	// get flags
 	flags := getDeactivationFlags()
 

--- a/cmd_cc_inactivate.go
+++ b/cmd_cc_inactivate.go
@@ -62,7 +62,7 @@ func getInactivateFlags() map[string]Flag {
 }
 
 // look into removing the args thing, might have to stay
-func inactivateFunction(cfg *Config, args []Argument) error {
+func inactivateFunction(cfg *Config) error {
 	// get flags
 	flags := getInactivateFlags()
 

--- a/cmd_cc_reactivate.go
+++ b/cmd_cc_reactivate.go
@@ -61,7 +61,7 @@ func getCCReactivateFlags() map[string]Flag {
 }
 
 // look into removing the args thing, might have to stay
-func reactivateFunction(cfg *Config, args []Argument) error {
+func reactivateFunction(cfg *Config) error {
 	// get flags
 	flags := getCCReactivateFlags()
 

--- a/cmd_common.go
+++ b/cmd_common.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"os"
 )
@@ -24,13 +23,8 @@ func getBackCmd() Command {
 
 	return backCmd
 }
-func backCommand(cfg *Config, args []Argument) error {
-	if len(args) != 0 {
-		return errors.New("back takes no params. Just takes you back to the main menu")
-	}
-
+func backCommand(cfg *Config) error {
 	cfg.nextState = getMainState()
-
 	return nil
 }
 
@@ -46,7 +40,7 @@ func getExitCmd() Command {
 
 // because you os exit this way, you never hit the end of the program to clean things
 // if you want to reset anything, put it here
-func exitCommand(cfg *Config, args []Argument) error {
+func exitCommand(cfg *Config) error {
 	fmt.Println("exiting...")
 	os.Exit(0)
 	return nil
@@ -64,7 +58,7 @@ func getStateHelpCmd() Command {
 	return helpCmd
 }
 
-func stateHelpCommand(cfg *Config, args []Argument) error {
+func stateHelpCommand(cfg *Config) error {
 	cmdMap := cfg.currentState.currentCommands
 	for _, key := range cmdMap {
 		fmt.Printf("* %s\n", key.name)

--- a/cmd_goto.go
+++ b/cmd_goto.go
@@ -1,7 +1,12 @@
 package main
 
-import "errors"
+import (
+	"bufio"
+	"fmt"
+	"os"
+)
 
+/* removed to make goto more consistent with other commands, and remove unused parameters from literally every command
 // separate out flags for consistency maybe
 func getSetStateCmd() Command {
 
@@ -80,7 +85,8 @@ func getSetStateCmd() Command {
 	return gotoCmd
 }
 
-func gotoCommand(cfg *Config, args []Argument) error {
+
+func gotoCommand(cfg *Config) error {
 	if len(args) == 0 {
 		return errors.New("goto requires a state flag")
 	}
@@ -109,6 +115,189 @@ func gotoCommand(cfg *Config, args []Argument) error {
 		cfg.nextState = getRemindersState()
 	default:
 		return errors.New("whoops a fake flag slipped into gotoCommand")
+	}
+
+	return nil
+}
+*/
+
+func getGotoCmd() Command {
+	gotoFlags := make(map[string]Flag)
+	gotoCmd := Command{
+		name:        "goto",
+		description: "Used for changing menus",
+		function:    gotoFunction,
+		flags:       gotoFlags,
+	}
+
+	return gotoCmd
+}
+
+func getGotoFlags() map[string]Flag {
+	gotoFlags := make(map[string]Flag)
+
+	ccFlag := Flag{
+		symbol:      "cc",
+		description: "Goes to CC processing menu.",
+		takesValue:  false,
+	}
+	gotoFlags["-"+ccFlag.symbol] = ccFlag
+
+	psFlag := Flag{
+		symbol:      "ps",
+		description: "Goes to positions menu.",
+		takesValue:  false,
+	}
+	gotoFlags["-"+psFlag.symbol] = psFlag
+
+	iFlag := Flag{
+		symbol:      "in",
+		description: "Goes to investigator menu.",
+		takesValue:  false,
+	}
+	gotoFlags["-"+iFlag.symbol] = iFlag
+
+	prFlag := Flag{
+		symbol:      "pr",
+		description: "Goes to protocol menu.",
+		takesValue:  false,
+	}
+	gotoFlags["-"+prFlag.symbol] = prFlag
+
+	seFlag := Flag{
+		symbol:      "se",
+		description: "Goes to settings menu.",
+		takesValue:  false,
+	}
+	gotoFlags["-"+seFlag.symbol] = seFlag
+
+	stFlag := Flag{
+		symbol:      "st",
+		description: "Goes to the strains menu.",
+		takesValue:  false,
+	}
+	gotoFlags["-"+stFlag.symbol] = stFlag
+
+	quFlag := Flag{
+		symbol:      "qu",
+		description: "Goes to the queries menu.",
+		takesValue:  false,
+	}
+	gotoFlags["-"+quFlag.symbol] = quFlag
+
+	orFlag := Flag{
+		symbol:      "or",
+		description: "Goes to the orders menu.",
+		takesValue:  false,
+	}
+	gotoFlags["-"+orFlag.symbol] = orFlag
+
+	rmFlag := Flag{
+		symbol:      "rm",
+		description: "Goes to the reminders menu.",
+		takesValue:  false,
+	}
+	gotoFlags["-"+rmFlag.symbol] = rmFlag
+
+	helpFlag := Flag{
+		symbol:      "help",
+		description: "Prints list of available flags",
+		takesValue:  false,
+	}
+	gotoFlags[helpFlag.symbol] = helpFlag
+
+	exitFlag := Flag{
+		symbol:      "exit",
+		description: "Exits without changing menu",
+		takesValue:  false,
+	}
+	gotoFlags[exitFlag.symbol] = exitFlag
+
+	return gotoFlags
+
+}
+
+// extremely simple function turned into some weird loop, all to remove a parameter from all the other functions
+func gotoFunction(cfg *Config) error {
+	// get flags
+	flags := getGotoFlags()
+
+	// set defaults
+	exit := false
+
+	// the reader
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Println("Enter the flag for the menu you'd like to go to. Enter 'help' to see list of available flags")
+	// da loop
+	for {
+		fmt.Print("> ")
+		text, err := reader.ReadString('\n')
+		if err != nil {
+			fmt.Printf("Error reading input string: %s", err)
+			os.Exit(1)
+		}
+
+		inputs, err := readSubcommandInput(text)
+		if err != nil {
+			fmt.Println(err)
+			continue
+		}
+
+		// do weird behavior here
+
+		// but normal loop now
+		args, err := parseArguments(flags, inputs)
+		if err != nil {
+			fmt.Println(err)
+			continue
+		}
+
+		if len(args) > 1 {
+			fmt.Println("Too many flags entered. Only really need one.")
+		}
+
+		for _, arg := range args {
+			switch arg.flag {
+			case "-cc":
+				cfg.nextState = getProcessingState()
+				exit = true
+			case "-ps":
+				cfg.nextState = getPositionState()
+				exit = true
+			case "-in":
+				cfg.nextState = getInvesitatorsState()
+				exit = true
+			case "-pr":
+				cfg.nextState = getProtocolState()
+				exit = true
+			case "-se":
+				cfg.nextState = getSettingsState()
+				exit = true
+			case "-st":
+				cfg.nextState = getStrainsState()
+				exit = true
+			case "-qu":
+				cfg.nextState = getQueriesState()
+				exit = true
+			case "-or":
+				cfg.nextState = getOrdersState()
+				exit = true
+			case "-rm":
+				cfg.nextState = getRemindersState()
+				exit = true
+			case "exit":
+				exit = true
+			case "help":
+				cmdHelp(flags)
+			default:
+				fmt.Printf("Oops a fake flag snuck in: %s\n", arg.flag)
+			}
+		}
+
+		if exit {
+			break
+		}
+
 	}
 
 	return nil

--- a/cmd_investigator.go
+++ b/cmd_investigator.go
@@ -101,7 +101,7 @@ func getEditInvestigatorFlags() map[string]Flag {
 // ask for a name, then pass in flags for everything
 // then print old to new
 // look into removing the args thing, might have to stay
-func editInvestigatorFunction(cfg *Config, args []Argument) error {
+func editInvestigatorFunction(cfg *Config) error {
 	investigator, err := getStructPrompt(cfg, "Enter the name of the investigator you'd like to edit,", getInvestigatorStruct)
 	if err != nil {
 		return err
@@ -354,7 +354,7 @@ func getAddInvestigatorFlags() map[string]Flag {
 // and always allow you to exit early or whatever
 // name, position, email, nickname, assume active
 // look into removing the args thing, might have to stay
-func addInvestigatorFunction(cfg *Config, args []Argument) error {
+func addInvestigatorFunction(cfg *Config) error {
 	name, err := getStringPrompt(cfg, "Enter name of new investigator", checkIfInvestigatorNameUnique)
 	if err != nil {
 		return err

--- a/cmd_orders.go
+++ b/cmd_orders.go
@@ -54,7 +54,7 @@ func getAddOrderFlags() map[string]Flag {
 }
 
 // look into removing the args thing, might have to stay
-func addOrderFunction(cfg *Config, args []Argument) error {
+func addOrderFunction(cfg *Config) error {
 	// get flags
 	flags := getAddOrderFlags()
 
@@ -324,7 +324,7 @@ func getEditOrderFlags() map[string]Flag {
 
 // look into removing the args thing, might have to stay
 // ask for an order number, load params, set flags
-func editOrderFunction(cfg *Config, args []Argument) error {
+func editOrderFunction(cfg *Config) error {
 	// get flags
 	flags := getEditOrderFlags()
 
@@ -550,7 +550,7 @@ func getReceiveOrderFlags() map[string]Flag {
 // as "this many cards will be added on this day this order ok"
 // then DO IT
 // look into removing the args thing, might have to stay
-func receiveOrderFunction(cfg *Config, args []Argument) error {
+func receiveOrderFunction(cfg *Config) error {
 	// flags just for saving and exiting prompt everything else
 	flags := getReceiveOrderFlags()
 

--- a/cmd_position.go
+++ b/cmd_position.go
@@ -109,7 +109,7 @@ func getPositionFlags() map[string]Flag {
 
 }
 
-func addPositionFunction(cfg *Config, args []Argument) error {
+func addPositionFunction(cfg *Config) error {
 	// get title before anything else, or exit early
 	title, err := getStringPrompt(cfg, "Please enter the title for the new position,", checkIfPositionTitleUnique)
 	if err != nil {
@@ -337,7 +337,7 @@ func getEditPositionCmd() Command {
 
 // TODO: print all titles so people know what the names are
 // flags are in addPosition
-func editPositionFunction(cfg *Config, args []Argument) error {
+func editPositionFunction(cfg *Config) error {
 	position, err := getStructPrompt(cfg, "Enter the title of the position to edit,", getPositionStruct)
 	if err != nil {
 		return err

--- a/cmd_protocol.go
+++ b/cmd_protocol.go
@@ -55,7 +55,7 @@ func getAddProtocolFlags() map[string]Flag {
 }
 
 // look into removing the args thing, might have to stay
-func addProtocolFunction(cfg *Config, args []Argument) error {
+func addProtocolFunction(cfg *Config) error {
 	// get flags
 	flags := getAddProtocolFlags()
 
@@ -349,7 +349,7 @@ func getEditProtocolFlags() map[string]Flag {
 }
 
 // look into removing the args thing, might have to stay
-func editProtocolFunction(cfg *Config, args []Argument) error {
+func editProtocolFunction(cfg *Config) error {
 	protocol, err := getStructPrompt(cfg, "Enter number of protocol to edit", checkProtocolExists)
 	if err != nil {
 		return err

--- a/cmd_protocol_investigator.go
+++ b/cmd_protocol_investigator.go
@@ -78,7 +78,7 @@ func getAddInvestToProtFlags() map[string]Flag {
 }
 
 // look into removing the args thing, might have to stay
-func addInvestigatorToProtocolFunction(cfg *Config, args []Argument) error {
+func addInvestigatorToProtocolFunction(cfg *Config) error {
 	// get flags
 	flags := getAddInvestToProtFlags()
 

--- a/cmd_queries_cc.go
+++ b/cmd_queries_cc.go
@@ -151,7 +151,7 @@ func getCCQueriesFlags() map[string]Flag {
 // look into removing the args thing, might have to stay
 // TODO: create a struct with an enum that remembers the query type, nulls the current values when you set a new one,
 // is easy to pass, run a switch on it
-func CCQueriesFunction(cfg *Config, args []Argument) error {
+func CCQueriesFunction(cfg *Config) error {
 	// get flags
 	flags := getCCQueriesFlags()
 

--- a/cmd_reminders.go
+++ b/cmd_reminders.go
@@ -58,7 +58,7 @@ func getAddReminderFlags() map[string]Flag {
 
 // look into removing the args thing, might have to stay
 // prompt stuff, then print or save it. that's about it.
-func addReminderFunction(cfg *Config, args []Argument) error {
+func addReminderFunction(cfg *Config) error {
 	// get flags
 	flags := getAddReminderFlags()
 
@@ -270,7 +270,7 @@ func getDeleteReminderCmd() Command {
 
 // get all the reminders for a certain date.
 // list them in whatever order, then enter 0 to delete or # to delete that one
-func deleteReminderFunction(cfg *Config, args []Argument) error {
+func deleteReminderFunction(cfg *Config) error {
 
 	var reminders []database.Reminder
 

--- a/cmd_settings.go
+++ b/cmd_settings.go
@@ -59,6 +59,13 @@ func getChangeSettingsFlags() map[string]Flag {
 	}
 	settingsFlags[exitFlag.symbol] = exitFlag
 
+	helpFlag := Flag{
+		symbol:      "help",
+		description: "Prints list of available commands.",
+		takesValue:  false,
+	}
+	settingsFlags[helpFlag.symbol] = helpFlag
+
 	// ect as needed or remove the "-"+ for longer ones
 
 	return settingsFlags
@@ -66,7 +73,7 @@ func getChangeSettingsFlags() map[string]Flag {
 }
 
 // look into removing the args thing, might have to stay
-func changeSettingsFunction(cfg *Config, args []Argument) error {
+func changeSettingsFunction(cfg *Config) error {
 	// get flags
 	flags := getChangeSettingsFlags()
 
@@ -136,6 +143,9 @@ func changeSettingsFunction(cfg *Config, args []Argument) error {
 			case "exit":
 				fmt.Println("Exiting without saving...")
 				exit = true
+
+			case "help":
+				cmdHelp(flags)
 			default:
 				fmt.Printf("Oops a fake flag snuck in: %s\n", arg.flag)
 			}

--- a/cmd_strain.go
+++ b/cmd_strain.go
@@ -55,7 +55,7 @@ func getAddStrainFlags() map[string]Flag {
 }
 
 // look into removing the args thing, might have to stay
-func addStrainFunction(cfg *Config, args []Argument) error {
+func addStrainFunction(cfg *Config) error {
 
 	name, err := getStringPrompt(cfg, "Enter strain name", checkFuncNil)
 	if err != nil {
@@ -252,7 +252,7 @@ func getEditStrainFlags() map[string]Flag {
 }
 
 // look into removing the args thing, might have to stay
-func editStrainFunction(cfg *Config, args []Argument) error {
+func editStrainFunction(cfg *Config) error {
 	nilStrain := database.Strain{}
 	strain, err := getStructPrompt(cfg, "Enter strain name or ID to edit", getStrainStruct)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -30,23 +30,17 @@ import (
 // do it
 
 // CURRENTLY:
-// reminders, orders
-// run tests before merging!
-// reminders have a CC#, can be set to automatically add to CC activation, or an order. do E something or other, or a reminder for ~21 days from now, or whatever
-// reminders show up for a person or for everybody
-// see reminders with dates for today, next week, export. no past stuff. once it's done, have it be done (dont delete it anyway)
-
-// fix CC activation
-// add the ability to automatically create reminders when entering breeding for next day or E something for E days + 1 or just reminder days then note something like that
+// removal of the []Arguments. It's only used by 'goto' and state setting. So change the way states work too. Then remove []Arguments from all the functions (many of them)
 
 // Next:
-// Cc activation is weak, make it a go routine that just does it as it goes. it's fast enough im sure and not http based. you're literally typing by hand. it's fake remember?
+// make maps print in a sorted order
+
+// Next:
+// add permissions that work (you can delete anybodys reminders currently)
 
 // AFTER THAT:
 // the great polishing
-// making maps print sortedly
-// adding permissions that work! you already have rolls. and logins
-// DRY up the state function, you don't need a separate function for each one. use a string and switch to return a state
+// logins (crpyto, storing that, creating new people, the admin tier account)
 // AFTER THAT:
 // the great readme-en-ing. write a readme and update the github page
 // AFTER THAT:
@@ -56,9 +50,6 @@ import (
 // the great job applyening, apply for jobs
 // DURING THAT:
 // the adding automated DB testing as well! cause that's a thing!
-// SOMEWHERE DURING THAT
-// i changed my mind and was cage cards to have go routines instead, so closer to cayuse process as you go
-// it's fast cause it's not html based
 // ADDITIONALLY:
 // a RESTful server version! throw out all your cli code and keep the sql! no more parsing! just json!
 
@@ -145,7 +136,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		cmdName, parameters, err := readCommandName(text)
+		cmdName, err := readCommandName(text)
 		if err != nil {
 			fmt.Println("oops error getting command name")
 			fmt.Println(err)
@@ -157,15 +148,17 @@ func main() {
 			fmt.Println("Invalid command")
 			continue
 		}
+		/* removed because arguments are no longer passed to commands (they were just never used)
 		// check to see if the flags are available, and if they take values, return flags and args
 		arguments, err := parseCommandArguments(&command, parameters)
 		if err != nil {
 			fmt.Println(err)
 			continue
 		}
+		*/
 
 		// pass the args into the commands function, then run it
-		err = command.function(&cfg, arguments)
+		err = command.function(&cfg)
 		if err != nil {
 			fmt.Println(err)
 			continue

--- a/states.go
+++ b/states.go
@@ -8,9 +8,9 @@ import (
 
 // just clean up the inputs
 // then we can have another function check and create the list of flags+args from the command
-func readCommandName(input string) (string, []string, error) {
+func readCommandName(input string) (string, error) {
 	if input == "" {
-		return "", nil, errors.New("no input found")
+		return "", errors.New("no input found")
 	}
 
 	splitArgs := strings.Split(input, " ")
@@ -18,17 +18,25 @@ func readCommandName(input string) (string, []string, error) {
 		splitArgs[i] = strings.TrimSpace(arg)
 	}
 
+	if len(splitArgs) > 1 {
+		fmt.Println("Too many command names entered. Only 1 is needed.")
+	}
+
 	cmdName := splitArgs[0]
+
+	/* formerly returned an array of strings that were never used
 	var arguments []string
 
 	if len(splitArgs) != 0 {
 		arguments = splitArgs[1:]
 	}
-
 	return cmdName, arguments, nil
+	*/
 
+	return cmdName, nil
 }
 
+/* removed because excessively complicated way to say "goto state." Removed with simplification of commands (but i still think it's clever)
 // for now used outside of commands but is a lot for what is essentially "goto this state"
 func parseCommandArguments(cmd *Command, parameters []string) ([]Argument, error) {
 	// no params passed in
@@ -71,6 +79,7 @@ func parseCommandArguments(cmd *Command, parameters []string) ([]Argument, error
 
 	return arguments, nil
 }
+*/
 
 // takes commands, adds common commands, then makes a map using its name as the key.
 // used in every state.
@@ -87,7 +96,7 @@ func cmdMapHelper(cmds []Command) map[string]Command {
 }
 
 func getMainMap() map[string]Command {
-	cmds := []Command{getSetStateCmd()}
+	cmds := []Command{getGotoCmd()}
 	commandMap := cmdMapHelper(cmds)
 
 	return commandMap

--- a/structs.go
+++ b/structs.go
@@ -22,7 +22,7 @@ type Argument struct {
 type Command struct {
 	name        string
 	description string
-	function    func(cfg *Config, args []Argument) error
+	function    func(cfg *Config) error
 	flags       map[string]Flag
 }
 


### PR DESCRIPTION
Removed the arguments param from all commands by changing Goto function
* Goto works more like a regular command (requires hitting enter twice!!! UI FRICTION!)
* That's about it but I've wanted to do it for a while